### PR TITLE
Circles

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -24,6 +24,8 @@ impl Draw for Game {
     fn draw(&mut self, ctx: &mut Context) {
         ctx.render
             .fill_text("Hello, world!", (10.0, 10.0), Color::WHITE);
+
+        ctx.render.set_color(Color::BLACK);
     }
 }
 

--- a/examples/controller.rs
+++ b/examples/controller.rs
@@ -30,34 +30,34 @@ impl Draw for Game {
         ctx.render.set_color(Color::GREEN);
 
         if ctx.input.button_down(Button::A) {
-            ctx.render.fill_circle((620, 360), 15);
+            ctx.render.fill_aa_circle((620, 360), 15);
         } else {
-            ctx.render.draw_circle((620, 360), 15);
+            ctx.render.draw_aa_circle((620, 360), 15);
         }
 
         ctx.render.set_color(Color::RED);
 
         if ctx.input.button_down(Button::B) {
-            ctx.render.fill_circle((650, 330), 15);
+            ctx.render.fill_aa_circle((650, 330), 15);
         } else {
-            ctx.render.draw_circle((650, 330), 15);
+            ctx.render.draw_aa_circle((650, 330), 15);
         }
 
         // Orange
         ctx.render.set_color(Color::RGB(255, 165, 0));
 
         if ctx.input.button_down(Button::Y) {
-            ctx.render.fill_circle((620, 300), 15);
+            ctx.render.fill_aa_circle((620, 300), 15);
         } else {
-            ctx.render.draw_circle((620, 300), 15);
+            ctx.render.draw_aa_circle((620, 300), 15);
         }
 
         ctx.render.set_color(Color::BLUE);
 
         if ctx.input.button_down(Button::X) {
-            ctx.render.fill_circle((590, 330), 15);
+            ctx.render.fill_aa_circle((590, 330), 15);
         } else {
-            ctx.render.draw_circle((590, 330), 15);
+            ctx.render.draw_aa_circle((590, 330), 15);
         }
 
         ctx.render.set_color(Color::WHITE);
@@ -91,7 +91,7 @@ impl Draw for Game {
         let ls_center = Vec2::new(250, 450);
         let actual_ls = ls_center + ls * 50;
 
-        ctx.render.draw_circle(ls_center, 50);
+        ctx.render.draw_aa_circle(ls_center, 50);
         ctx.render.draw_line(ls_center, actual_ls);
         ctx.render.fill_aa_circle(actual_ls, 5);
 
@@ -103,7 +103,7 @@ impl Draw for Game {
 
         ctx.render.set_color(Color::WHITE);
 
-        ctx.render.draw_circle(rs_center, 50);
+        ctx.render.draw_aa_circle(rs_center, 50);
         ctx.render.draw_line(rs_center, actual_rs);
         ctx.render.fill_aa_circle(actual_rs, 5);
 

--- a/examples/shapes.rs
+++ b/examples/shapes.rs
@@ -21,13 +21,16 @@ impl Update for Game {
 impl Draw for Game {
     fn draw(&mut self, ctx: &mut Context) {
         ctx.render.set_color(Color::GREEN);
+
+        ctx.render.draw_arc((100, 400), 40, 45.0, 180.0);
+
         ctx.render.draw_circle((100, 100), 50);
 
         ctx.render.set_color(Color::RED);
 
         ctx.render.draw_aa_circle((500, 300), 100);
 
-        ctx.render.draw_circle((200, 200), 50);
+        ctx.render.draw_circle((200, 200), 75);
 
         ctx.render.set_color(Color::BLUE);
 

--- a/src/math/circles.rs
+++ b/src/math/circles.rs
@@ -1,0 +1,318 @@
+use sdl2::{
+    pixels::{Color, PixelFormatEnum},
+    render::{BlendMode, Texture, TextureCreator},
+    video::WindowContext,
+};
+
+pub(crate) trait CircleOutline<'a> {
+    fn arc(
+        texture_creator: &'a TextureCreator<WindowContext>,
+        radius: u32,
+        start_angle: f32,
+        end_angle: f32,
+    ) -> Texture<'a>;
+
+    fn circle_outline(
+        texture_creator: &'a TextureCreator<WindowContext>,
+        radius: u32,
+    ) -> Texture<'a>;
+
+    fn aa_circle_outline(
+        texture_creator: &'a TextureCreator<WindowContext>,
+        radius: u32,
+    ) -> Texture<'a>;
+}
+
+impl<'a> CircleOutline<'a> for Texture<'a> {
+    fn arc(
+        texture_creator: &'a TextureCreator<WindowContext>,
+        radius: u32,
+        start_angle: f32,
+        end_angle: f32,
+    ) -> Texture<'a> {
+        let d = radius * 2;
+        let mut texture = texture_creator
+            .create_texture_streaming(PixelFormatEnum::RGBA32, d + 1, d + 1)
+            .unwrap();
+
+        texture.set_blend_mode(BlendMode::Blend);
+
+        texture
+            .with_lock(None, |buffer, pitch| {
+                let mut t1 = (radius / 16) as i32;
+                let mut t2;
+                let mut x = radius as i32;
+                let mut y = 0 as i32;
+
+                let center = radius as i32;
+
+                let start_angle = start_angle.to_radians();
+                let end_angle = end_angle.to_radians();
+
+                while x >= y {
+                    let points = [
+                        (x, y),
+                        (y, x),
+                        (-y, x),
+                        (-x, y),
+                        (-x, -y),
+                        (-y, -x),
+                        (y, -x),
+                        (x, -y),
+                    ];
+
+                    for &(px, py) in points.iter() {
+                        let dx = center + px;
+                        let dy = center + py;
+
+                        let angle = (py as f32).atan2(px as f32);
+                        let normalized_angle = if angle < 0.0 {
+                            angle + 2.0 * std::f32::consts::PI
+                        } else {
+                            angle
+                        };
+
+                        if normalized_angle >= start_angle && normalized_angle <= end_angle {
+                            set_pixel(buffer, pitch, dx, dy, Color::WHITE);
+                        }
+                    }
+
+                    y += 1;
+                    t1 += y;
+                    t2 = t1 - x;
+
+                    if t2 >= 0 {
+                        t1 = t2;
+                        x -= 1;
+                    }
+                }
+            })
+            .unwrap();
+
+        texture
+    }
+
+    fn circle_outline(
+        texture_creator: &'a TextureCreator<WindowContext>,
+        radius: u32,
+    ) -> Texture<'a> {
+        let d = radius * 2;
+        let color = Color::WHITE;
+        let mut texture = texture_creator
+            .create_texture_streaming(PixelFormatEnum::RGBA32, d + 1, d + 1)
+            .unwrap();
+
+        texture.set_blend_mode(BlendMode::Blend);
+
+        texture
+            .with_lock(None, |buffer: &mut [u8], pitch: usize| {
+                let (cx, cy) = (radius as i32, radius as i32);
+                let mut x = radius as i32;
+                let mut y = 0;
+                let mut err = 1 - x;
+
+                while x >= y {
+                    set_pixel(buffer, pitch, cx + x, cy + y, color);
+                    set_pixel(buffer, pitch, cx + y, cy + x, color);
+                    set_pixel(buffer, pitch, cx - y, cy + x, color);
+                    set_pixel(buffer, pitch, cx - x, cy + y, color);
+                    set_pixel(buffer, pitch, cx - x, cy - y, color);
+                    set_pixel(buffer, pitch, cx - y, cy - x, color);
+                    set_pixel(buffer, pitch, cx + y, cy - x, color);
+                    set_pixel(buffer, pitch, cx + x, cy - y, color);
+
+                    y += 1;
+                    if err < 0 {
+                        err += 2 * y + 1;
+                    } else {
+                        x -= 1;
+                        err += 2 * (y - x + 1);
+                    }
+                }
+            })
+            .unwrap();
+
+        texture
+    }
+
+    fn aa_circle_outline(
+        texture_creator: &'a TextureCreator<WindowContext>,
+        radius: u32,
+    ) -> Texture<'a> {
+        let d = radius * 2;
+        let color = Color::WHITE;
+        let mut texture = texture_creator
+            .create_texture_streaming(PixelFormatEnum::RGBA32, d + 1, d + 1)
+            .unwrap();
+
+        texture.set_blend_mode(BlendMode::Blend);
+
+        texture
+            .with_lock(None, |buffer: &mut [u8], pitch: usize| {
+                let radius = radius as f32;
+                let center = radius;
+
+                for y in 0..=d {
+                    for x in 0..=d {
+                        let dx = x as f32 - center;
+                        let dy = y as f32 - center;
+                        let distance = (dx * dx + dy * dy).sqrt();
+                        let coverage = 1.0 - (distance - radius).abs().min(1.0);
+
+                        if coverage > 0.0 {
+                            let alpha = (color.a as f32 * coverage) as u8;
+                            let blended_color = Color::RGBA(color.r, color.g, color.b, alpha);
+                            set_pixel(buffer, pitch, x as i32, y as i32, blended_color);
+                        }
+                    }
+                }
+            })
+            .unwrap();
+
+        texture
+    }
+}
+
+pub(crate) trait CircleFill<'a> {
+    fn circle_fill(texture_creator: &'a TextureCreator<WindowContext>, radius: u32) -> Texture<'a>;
+
+    fn aa_circle_fill(
+        texture_creator: &'a TextureCreator<WindowContext>,
+        radius: u32,
+    ) -> Texture<'a>;
+}
+
+impl<'a> CircleFill<'a> for Texture<'a> {
+    fn circle_fill(texture_creator: &'a TextureCreator<WindowContext>, radius: u32) -> Texture<'a> {
+        let d = radius * 2;
+        let color = Color::WHITE;
+        let mut texture = texture_creator
+            .create_texture_streaming(PixelFormatEnum::RGBA32, d + 1, d + 1)
+            .unwrap();
+
+        texture.set_blend_mode(BlendMode::Blend);
+
+        texture
+            .with_lock(None, |buffer: &mut [u8], pitch: usize| {
+                let (cx, cy) = (radius as i32, radius as i32);
+                let mut x = radius as i32;
+                let mut y = 0;
+                let mut err = 1 - x;
+
+                while x >= y {
+                    set_pixel(buffer, pitch, cx + x, cy + y, color);
+                    set_pixel(buffer, pitch, cx + y, cy + x, color);
+                    set_pixel(buffer, pitch, cx - y, cy + x, color);
+                    set_pixel(buffer, pitch, cx - x, cy + y, color);
+                    set_pixel(buffer, pitch, cx - x, cy - y, color);
+                    set_pixel(buffer, pitch, cx - y, cy - x, color);
+                    set_pixel(buffer, pitch, cx + y, cy - x, color);
+                    set_pixel(buffer, pitch, cx + x, cy - y, color);
+
+                    y += 1;
+                    if err < 0 {
+                        err += 2 * y + 1;
+                    } else {
+                        x -= 1;
+                        err += 2 * (y - x + 1);
+                    }
+                }
+
+                let is_in_circle = |x: i32, y: i32| -> bool {
+                    let dx = x as f32 - radius as f32;
+                    let dy = y as f32 - radius as f32;
+                    let distance = (dx * dx + dy * dy).sqrt();
+                    distance <= radius as f32
+                };
+
+                for y in 0..=d {
+                    for x in 0..=d {
+                        if is_in_circle(x as i32, y as i32) {
+                            set_pixel(buffer, pitch, x as i32, y as i32, color);
+                        }
+                    }
+                }
+            })
+            .unwrap();
+
+        texture
+    }
+
+    fn aa_circle_fill(
+        texture_creator: &'a TextureCreator<WindowContext>,
+        radius: u32,
+    ) -> Texture<'a> {
+        let d = radius * 2;
+        let color = Color::WHITE;
+        let mut texture = texture_creator
+            .create_texture_streaming(PixelFormatEnum::RGBA32, d + 1, d + 1) // Ensure texture size is d + 1 by d + 1
+            .unwrap();
+
+        texture.set_blend_mode(BlendMode::Blend);
+
+        texture
+            .with_lock(None, |buffer, pitch| {
+                let (cx, cy) = (radius as i32, radius as i32);
+                let samples = 4;
+
+                for y in 0..d {
+                    for x in 0..d {
+                        let mut alpha_sum = 0.0;
+
+                        for sy in 0..samples {
+                            for sx in 0..samples {
+                                let sub_x = x as f32 + (sx as f32 + 0.5) / samples as f32;
+                                let sub_y = y as f32 + (sy as f32 + 0.5) / samples as f32;
+                                let dx = sub_x - cx as f32;
+                                let dy = sub_y - cy as f32;
+                                let dist = (dx * dx + dy * dy).sqrt();
+
+                                let alpha = if dist < radius as f32 {
+                                    1.0
+                                } else if dist < radius as f32 + 1.0 {
+                                    1.0 - (dist - radius as f32)
+                                } else {
+                                    0.0
+                                };
+                                alpha_sum += alpha;
+                            }
+                        }
+
+                        let alpha = alpha_sum / (samples * samples) as f32;
+
+                        if alpha > 0.0 {
+                            blend_pixel(buffer, pitch, x as i32, y as i32, color, alpha);
+                        }
+                    }
+                }
+            })
+            .unwrap();
+
+        texture
+    }
+}
+
+fn set_pixel(buffer: &mut [u8], pitch: usize, x: i32, y: i32, color: Color) {
+    if x < 0 || y < 0 || x >= pitch as i32 / 4 || y >= pitch as i32 / 4 {
+        return;
+    }
+    let offset = (y as usize * pitch) + (x as usize * 4);
+    buffer[offset] = color.r;
+    buffer[offset + 1] = color.g;
+    buffer[offset + 2] = color.b;
+    buffer[offset + 3] = color.a;
+}
+
+fn blend_pixel(buffer: &mut [u8], pitch: usize, x: i32, y: i32, color: Color, alpha: f32) {
+    if x < 0 || y < 0 || x >= pitch as i32 / 4 || y >= pitch as i32 / 4 {
+        return;
+    }
+
+    let inv_alpha = 1.0 - alpha;
+
+    let offset = (y as usize * pitch) + (x as usize * 4);
+    buffer[offset] = (buffer[offset] as f32 * inv_alpha + color.r as f32 * alpha) as u8;
+    buffer[offset + 1] = (buffer[offset + 1] as f32 * inv_alpha + color.g as f32 * alpha) as u8;
+    buffer[offset + 2] = (buffer[offset + 2] as f32 * inv_alpha + color.b as f32 * alpha) as u8;
+    buffer[offset + 3] = (buffer[offset + 3] as f32 * inv_alpha + color.a as f32 * alpha) as u8;
+}

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -2,6 +2,8 @@ mod random;
 mod size;
 mod vec2;
 
+pub(crate) mod circles;
+
 pub use random::{coin_flip, pick, rng};
 pub use size::Size;
 pub use vec2::Vec2;

--- a/src/render/renderer.rs
+++ b/src/render/renderer.rs
@@ -419,7 +419,8 @@ impl Renderer {
                 texture
                     .with_lock(None, |buffer, _| {
                         let outline_thickness = 4.0f32;
-                        let center = radius as f32;
+                        // Move the center otherwise the circle will be cut off
+                        let center = radius as f32 + 0.5;
                         let samples = 4;
 
                         for y in 0..diameter {

--- a/src/render/renderer.rs
+++ b/src/render/renderer.rs
@@ -3,14 +3,17 @@ use super::{
     font::Font,
 };
 use crate::{
-    math::{Size, ToU32, Vec2},
+    math::{
+        circles::{CircleFill, CircleOutline},
+        Size, ToU32, Vec2,
+    },
     traits::LoadSurface,
 };
 use fontdue::layout::TextStyle;
 use sdl2::{
-    pixels::{Color, PixelFormatEnum},
+    pixels::Color,
     rect::{FPoint, FRect},
-    render::{BlendMode, Canvas, Texture, TextureCreator},
+    render::{Canvas, Texture, TextureCreator},
     surface::Surface,
     video::{Window, WindowContext},
 };
@@ -57,39 +60,6 @@ impl Renderer {
             images: HashMap::new(),
             atlas,
         }
-    }
-
-    fn set_pixel_color(buffer: &mut [u8], i: usize, color: Color) {
-        #[cfg(target_endian = "big")]
-        {
-            buffer[i] = color.r;
-            buffer[i + 1] = color.g;
-            buffer[i + 2] = color.b;
-            buffer[i + 3] = color.a;
-        }
-
-        #[cfg(target_endian = "little")]
-        {
-            buffer[i] = color.a;
-            buffer[i + 1] = color.b;
-            buffer[i + 2] = color.g;
-            buffer[i + 3] = color.r;
-        }
-    }
-
-    fn blend_pixel_color(buffer: &mut [u8], index: usize, color: Color, alpha: f32) {
-        let inv_alpha = 1.0 - alpha;
-
-        Self::set_pixel_color(
-            buffer,
-            index,
-            Color {
-                r: (color.r as f32 * alpha + buffer[index] as f32 * inv_alpha) as u8,
-                g: (color.g as f32 * alpha + buffer[index + 1] as f32 * inv_alpha) as u8,
-                b: (color.b as f32 * alpha + buffer[index + 2] as f32 * inv_alpha) as u8,
-                a: (color.a as f32 * alpha + buffer[index + 3] as f32 * inv_alpha) as u8,
-            },
-        );
     }
 
     pub fn load_font<L: ToString, P: AsRef<Path>>(&mut self, label: L, path: P, size: f32) {
@@ -242,67 +212,7 @@ impl Renderer {
             if let Some(texture) = self.atlas.get_texture(kind) {
                 texture
             } else {
-                let mut texture = texture_creator()
-                    .create_texture_streaming(PixelFormatEnum::RGBA32, diameter, diameter)
-                    .unwrap();
-
-                texture.set_blend_mode(BlendMode::Blend);
-
-                texture
-                    .with_lock(None, |buffer, _| {
-                        let mut t1 = (radius / 16) as i32;
-                        let mut t2;
-                        let mut x = radius as i32;
-                        let mut y = 0 as i32;
-
-                        let center = radius as i32;
-
-                        let start_angle = start_angle.to_radians();
-                        let end_angle = end_angle.to_radians();
-
-                        while x >= y {
-                            let points = [
-                                (x, y),
-                                (y, x),
-                                (-y, x),
-                                (-x, y),
-                                (-x, -y),
-                                (-y, -x),
-                                (y, -x),
-                                (x, -y),
-                            ];
-
-                            for &(px, py) in points.iter() {
-                                let dx = center + px;
-                                let dy = center + py;
-
-                                // Calculate angle of the point
-                                let angle = (py as f32).atan2(px as f32);
-                                let normalized_angle = if angle < 0.0 {
-                                    angle + 2.0 * std::f32::consts::PI
-                                } else {
-                                    angle
-                                };
-
-                                // Check if the angle is within the range
-                                if normalized_angle >= start_angle && normalized_angle <= end_angle
-                                {
-                                    let i = (dy * diameter as i32 + dx) as usize * 4;
-                                    Self::set_pixel_color(buffer, i, Color::WHITE);
-                                }
-                            }
-
-                            y += 1;
-                            t1 += y;
-                            t2 = t1 - x;
-
-                            if t2 >= 0 {
-                                t1 = t2;
-                                x -= 1;
-                            }
-                        }
-                    })
-                    .unwrap();
+                let texture = Texture::arc(texture_creator(), radius, start_angle, end_angle);
 
                 self.atlas.insert_texture(kind, texture);
                 self.atlas.get_texture(kind).unwrap()
@@ -324,7 +234,7 @@ impl Renderer {
     pub fn draw_circle<P: Into<Vec2>, U: ToU32>(&mut self, center: P, radius: U) {
         let center = center.into();
         let radius = radius.to_u32();
-        let diameter = radius * 2 + 1;
+        let diameter = radius * 2;
         let color = self.color();
 
         let kind = TextureKind::Circle(radius);
@@ -333,53 +243,7 @@ impl Renderer {
             if let Some(texture) = self.atlas.get_texture(kind) {
                 texture
             } else {
-                let mut texture = texture_creator()
-                    .create_texture_streaming(PixelFormatEnum::RGBA32, diameter, diameter)
-                    .unwrap();
-
-                texture.set_blend_mode(BlendMode::Blend);
-
-                texture
-                    .with_lock(None, |buffer, _| {
-                        let mut t1 = (radius / 16) as i32;
-                        let mut t2;
-                        let mut x = radius as i32;
-                        let mut y = 0 as i32;
-
-                        let center = radius as i32;
-
-                        while x >= y {
-                            let points = [
-                                (x, y),
-                                (y, x),
-                                (-y, x),
-                                (-x, y),
-                                (-x, -y),
-                                (-y, -x),
-                                (y, -x),
-                                (x, -y),
-                            ];
-
-                            for (x, y) in points.iter() {
-                                let dx = center + x;
-                                let dy = center + y;
-
-                                let i = (dy * diameter as i32 + dx) as usize * 4;
-
-                                Self::set_pixel_color(buffer, i, Color::WHITE);
-                            }
-
-                            y += 1;
-                            t1 += y;
-                            t2 = t1 - x;
-
-                            if t2 >= 0 {
-                                t1 = t2;
-                                x -= 1;
-                            }
-                        }
-                    })
-                    .unwrap();
+                let texture = Texture::circle_outline(texture_creator(), radius);
 
                 self.atlas.insert_texture(kind, texture);
                 self.atlas.get_texture(kind).unwrap()
@@ -401,7 +265,7 @@ impl Renderer {
     pub fn draw_aa_circle<P: Into<Vec2>, U: ToU32>(&mut self, center: P, radius: U) {
         let center = center.into();
         let radius = radius.to_u32();
-        let diameter = radius * 2 + 1;
+        let diameter = radius * 2;
         let color = self.color();
 
         let kind = TextureKind::AACircle(radius);
@@ -410,56 +274,7 @@ impl Renderer {
             if let Some(texture) = self.atlas.get_texture(kind) {
                 texture
             } else {
-                let mut texture = texture_creator()
-                    .create_texture_streaming(PixelFormatEnum::RGBA32, diameter, diameter)
-                    .unwrap();
-
-                texture.set_blend_mode(BlendMode::Blend);
-
-                texture
-                    .with_lock(None, |buffer, _| {
-                        let outline_thickness = 4.0f32;
-                        // Move the center otherwise the circle will be cut off
-                        let center = radius as f32 + 0.5;
-                        let samples = 4;
-
-                        for y in 0..diameter {
-                            for x in 0..diameter {
-                                let mut alpha_sum = 0.0;
-
-                                for sy in 0..samples {
-                                    for sx in 0..samples {
-                                        let sub_x = x as f32 + (sx as f32 + 0.5) / samples as f32;
-                                        let sub_y = y as f32 + (sy as f32 + 0.5) / samples as f32;
-                                        let dx = sub_x - center;
-                                        let dy = sub_y - center;
-                                        let distance = (dx * dx + dy * dy).sqrt();
-
-                                        let inner_edge = radius as f32 - outline_thickness / 2.0;
-                                        let outer_edge = radius as f32 + outline_thickness / 2.0;
-
-                                        let alpha =
-                                            if distance >= inner_edge && distance <= outer_edge {
-                                                1.0 - ((distance - radius as f32).abs()
-                                                    / (outline_thickness / 2.0))
-                                            } else {
-                                                0.0
-                                            };
-                                        alpha_sum += alpha;
-                                    }
-                                }
-
-                                let alpha = alpha_sum / (samples * samples) as f32;
-
-                                if alpha > 0.0 {
-                                    let i = ((y as u32 * diameter + x as u32) * 4) as usize;
-                                    Self::blend_pixel_color(buffer, i, color, alpha);
-                                }
-                            }
-                        }
-                    })
-                    .unwrap();
-
+                let texture = Texture::aa_circle_outline(texture_creator(), radius);
                 self.atlas.insert_texture(kind, texture);
                 self.atlas.get_texture(kind).unwrap()
             }
@@ -489,56 +304,7 @@ impl Renderer {
             if let Some(texture) = self.atlas.get_texture(kind) {
                 texture
             } else {
-                let mut texture = texture_creator()
-                    .create_texture_streaming(PixelFormatEnum::RGBA32, diameter, diameter)
-                    .unwrap();
-
-                texture.set_blend_mode(BlendMode::Blend);
-
-                texture
-                    .with_lock(None, |buffer, _| {
-                        let mut t1 = (radius / 16) as i32;
-                        let mut t2;
-                        let mut x = radius as i32;
-                        let mut y = 0 as i32;
-
-                        let center = radius as i32;
-
-                        while x >= y {
-                            for dy in -y..y {
-                                let x1 = center - x;
-                                let x2 = center + x;
-
-                                for dx in x1..x2 {
-                                    let i = (dy + center) * diameter as i32 + dx;
-                                    Self::set_pixel_color(buffer, i as usize * 4, Color::WHITE);
-                                }
-                            }
-
-                            for dy in -x..x {
-                                let y1 = center - y;
-                                let y2 = center + y;
-
-                                for dx in y1..y2 {
-                                    let nx = dx;
-                                    let ny = center + dy;
-
-                                    let i = ny * diameter as i32 + nx;
-                                    Self::set_pixel_color(buffer, i as usize * 4, Color::WHITE);
-                                }
-                            }
-
-                            y += 1;
-                            t1 += y;
-                            t2 = t1 - x;
-
-                            if t2 >= 0 {
-                                t1 = t2;
-                                x -= 1;
-                            }
-                        }
-                    })
-                    .unwrap();
+                let texture = Texture::circle_fill(texture_creator(), radius);
 
                 self.atlas.insert_texture(kind, texture);
                 self.atlas.get_texture(kind).unwrap()
@@ -568,50 +334,7 @@ impl Renderer {
         let texture = if let Some(texture) = self.atlas.get_texture(kind) {
             texture
         } else {
-            let mut texture = texture_creator()
-                .create_texture_streaming(PixelFormatEnum::RGBA8888, diameter, diameter)
-                .unwrap();
-
-            texture.set_blend_mode(BlendMode::Blend);
-
-            texture
-                .with_lock(None, |buffer, _| {
-                    let center = radius as i32;
-                    let samples = 4;
-
-                    for y in 0..diameter {
-                        for x in 0..diameter {
-                            let mut alpha_sum = 0.0;
-
-                            for sy in 0..samples {
-                                for sx in 0..samples {
-                                    let sub_x = x as f32 + (sx as f32 + 0.5) / samples as f32;
-                                    let sub_y = y as f32 + (sy as f32 + 0.5) / samples as f32;
-                                    let dx = sub_x - center as f32;
-                                    let dy = sub_y - center as f32;
-                                    let distance = (dx * dx + dy * dy).sqrt();
-
-                                    let alpha = if distance < radius as f32 {
-                                        1.0
-                                    } else if distance < radius as f32 + 1.0 {
-                                        1.0 - (distance - radius as f32)
-                                    } else {
-                                        0.0
-                                    };
-                                    alpha_sum += alpha;
-                                }
-                            }
-
-                            let alpha = alpha_sum / (samples * samples) as f32;
-
-                            if alpha > 0.0 {
-                                let i = ((y as u32 * diameter + x as u32) * 4) as usize;
-                                Self::blend_pixel_color(buffer, i, color, alpha);
-                            }
-                        }
-                    }
-                })
-                .unwrap();
+            let texture = Texture::aa_circle_fill(texture_creator(), radius);
 
             self.atlas.insert_texture(kind, texture);
             self.atlas.get_texture(kind).unwrap()


### PR DESCRIPTION
Implement circle traits for textures, which serve the purpose to create and cache circle shapes (filled, anti-aliased, etc.) for sdl textures